### PR TITLE
Fixed a few bugs in MCIndexSet/MCRange that were messing up some of my extreme case unit tests.

### DIFF
--- a/src/core/basetypes/MCIndexSet.cpp
+++ b/src/core/basetypes/MCIndexSet.cpp
@@ -367,12 +367,14 @@ Object * IndexSet::copy()
 
 void IndexSet::intersectsRange(Range range)
 {
-    uint64_t right = RangeRightBound(range);
-    if (right == UINT64_MAX) {
-        removeRange(RangeMake(0, range.location - 1));
+    // Remove to the left of range if there are values there
+    uint64_t left = RangeLeftBound(range);
+    if (left > 0) {
+        removeRange(RangeMake(0, left - 1));
     }
-    else {
-        removeRange(RangeMake(0, range.location - 1));
+    // Remove to the right of range if there are values there
+    uint64_t right = RangeRightBound(range);
+    if (right != UINT64_MAX) {
         removeRange(RangeMake(right + 1, UINT64_MAX));
     }
 }
@@ -405,8 +407,9 @@ bool IndexSet::isEqual(Object * otherObject)
         return false;
     }
     for(unsigned int i = 0 ; i < mCount ; i ++) {
-        if ((mRanges[i].location != otherIndexSet->mRanges[i].location) ||
-            (mRanges[i].length != otherIndexSet->mRanges[i].length)) {
+        // Calculate the range bounds using accessor functions to catch overflow and underflow cases
+        if ((RangeLeftBound(mRanges[i]) != RangeLeftBound(otherIndexSet->mRanges[i])) ||
+            (RangeRightBound(mRanges[i]) != RangeRightBound(otherIndexSet->mRanges[i]))) {
             return false;
         }
     }

--- a/src/core/basetypes/MCRange.cpp
+++ b/src/core/basetypes/MCRange.cpp
@@ -144,7 +144,8 @@ uint64_t mailcore::RangeLeftBound(Range range)
 
 uint64_t mailcore::RangeRightBound(Range range)
 {
-    if (range.length == UINT64_MAX)
+    // If range.location + range.lenth would overflow then clamp to UINT64_MAX to indicate infinity
+    if (UINT64_MAX - range.location <= range.length)
         return UINT64_MAX;
     return range.location + range.length;
 }


### PR DESCRIPTION
- The IndexSet::intersectsRange method was underflowing when the range to move was at location 0.
- It is possible to construct two ranges that denote the same index values if the values are at the end of the valid interval. For instance MCRange(UINT64_MAX, 10) and MCRange(UINT64_MAX, 20) both only cover the index UINT64_MAX which is undefined. This is normally ok, but if two index sets were defined with the different ranges they would not compare equal because the definition of the ranges was different even though it had the same effect. I didn't fix the construction of the ranges in case some code was depending on the 'overflow' ability of the current implementation, instead I fixed isEqual() to use RangeRightBound() and fixed a bug in RangeRightBound() to clamp the value properly when an overflow occurred. (There was a bug in RangeRightBound() that would only clamp the value when length was UINT64_MAX, but the value would overflow whenever location + length > UINT64_MAX).

NOTE: I wanted to write a unit test for these changes, but there were no existing unit tests for MCIndexSet and MCRange, so I decided not to open that can of worms.