### PR TITLE
Exposed the isConstoreEnabled and isQResyncEnabled properties of MCIMAPSession to MCIMAPAsyncSession.

### DIFF
--- a/src/async/imap/MCIMAPAsyncSession.cpp
+++ b/src/async/imap/MCIMAPAsyncSession.cpp
@@ -249,6 +249,16 @@ bool IMAPAsyncSession::isGmail()
     return mIsGmail;
 }
 
+bool IMAPAsyncSession::isCondstoreEnabled()
+{
+    return mIsCondstoreEnabled;
+}
+
+bool IMAPAsyncSession::isQResyncEnabled()
+{
+    return mIsQResyncEnabled;
+}
+
 String * IMAPAsyncSession::gmailUserDisplayName()
 {
     return mGmailUserDisplayName;
@@ -878,6 +888,8 @@ void IMAPAsyncSession::automaticConfigurationDone(IMAPSession * session)
 {
     MC_SAFE_REPLACE_COPY(IMAPIdentity, mServerIdentity, session->serverIdentity());
     mIsGmail = session->isGmail();
+    mIsCondstoreEnabled = session->isCondstoreEnabled();
+    mIsQResyncEnabled = session->isQResyncEnabled();
     MC_SAFE_REPLACE_COPY(String, mGmailUserDisplayName, session->gmailUserDisplayName());
     mIdleEnabled = session->isIdleEnabled();
     setDefaultNamespace(session->defaultNamespace());

--- a/src/async/imap/MCIMAPAsyncSession.h
+++ b/src/async/imap/MCIMAPAsyncSession.h
@@ -109,6 +109,8 @@ namespace mailcore {
         virtual void setClientIdentity(IMAPIdentity * clientIdentity);
 
         virtual bool isGmail();
+        virtual bool isCondstoreEnabled();
+        virtual bool isQResyncEnabled();
         virtual String * gmailUserDisplayName() DEPRECATED_ATTRIBUTE;
 
         virtual bool isIdleEnabled();
@@ -218,6 +220,8 @@ namespace mailcore {
         dispatch_queue_t mDispatchQueue;
 #endif
         bool mIsGmail;
+        bool mIsCondstoreEnabled;
+        bool mIsQResyncEnabled;
         String * mGmailUserDisplayName;
         bool mIdleEnabled;
 

--- a/src/objc/imap/MCOIMAPSession.h
+++ b/src/objc/imap/MCOIMAPSession.h
@@ -96,6 +96,12 @@
 /** If the server is Gmail */
 @property (nonatomic, assign, readonly) BOOL isGmail;
 
+/** Does the server support CONDSTORE */
+@property (nonatomic, assign, readonly) BOOL isCondstoreEnabled;
+
+/** Does the server support QRESYNC */
+@property (nonatomic, assign, readonly) BOOL isQResyncEnabled;
+
 /**
  Display name of the Gmail user. It will be nil if it's not a Gmail server.
 

--- a/src/objc/imap/MCOIMAPSession.mm
+++ b/src/objc/imap/MCOIMAPSession.mm
@@ -139,6 +139,15 @@ MCO_OBJC_SYNTHESIZE_SCALAR(dispatch_queue_t, dispatch_queue_t, setDispatchQueue,
     return MCO_NATIVE_INSTANCE->isGmail();
 }
 
+- (BOOL) isCondstoreEnabled
+{
+    return MCO_NATIVE_INSTANCE->isCondstoreEnabled();
+}
+
+- (BOOL) isQResyncEnabled {
+    return MCO_NATIVE_INSTANCE->isQResyncEnabled();
+}
+
 - (NSString *) gmailUserDisplayName
 {
     return MCO_TO_OBJC(_session->gmailUserDisplayName());


### PR DESCRIPTION
This is kind of gross, and makes me think that there's a better way to do this, but I can't figure out what it is. It would be simpler if the async session kept a reference back to the base session so that the information didn't need to be copied out.