### PR TITLE
Exposed the isMoveEnabled property from low level mail core to the objective C wrapper.

### DIFF
--- a/src/async/imap/MCIMAPAsyncSession.cpp
+++ b/src/async/imap/MCIMAPAsyncSession.cpp
@@ -76,6 +76,7 @@ IMAPAsyncSession::IMAPAsyncSession()
     mDispatchQueue = dispatch_get_main_queue();
 #endif
     mIsGmail = false;
+    mIsMoveEnabled = false;
     mGmailUserDisplayName = NULL;
     mQueueRunning = false;
     mIdleEnabled = false;
@@ -247,6 +248,11 @@ void IMAPAsyncSession::setClientIdentity(IMAPIdentity * clientIdentity)
 bool IMAPAsyncSession::isGmail()
 {
     return mIsGmail;
+}
+
+bool IMAPAsyncSession::isMoveEnabled()
+{
+    return mIsMoveEnabled;
 }
 
 bool IMAPAsyncSession::isCondstoreEnabled()
@@ -888,6 +894,7 @@ void IMAPAsyncSession::automaticConfigurationDone(IMAPSession * session)
 {
     MC_SAFE_REPLACE_COPY(IMAPIdentity, mServerIdentity, session->serverIdentity());
     mIsGmail = session->isGmail();
+    mIsMoveEnabled = session->isMoveEnabled();
     mIsCondstoreEnabled = session->isCondstoreEnabled();
     mIsQResyncEnabled = session->isQResyncEnabled();
     MC_SAFE_REPLACE_COPY(String, mGmailUserDisplayName, session->gmailUserDisplayName());

--- a/src/async/imap/MCIMAPAsyncSession.h
+++ b/src/async/imap/MCIMAPAsyncSession.h
@@ -109,6 +109,7 @@ namespace mailcore {
         virtual void setClientIdentity(IMAPIdentity * clientIdentity);
 
         virtual bool isGmail();
+        virtual bool isMoveEnabled();
         virtual bool isCondstoreEnabled();
         virtual bool isQResyncEnabled();
         virtual String * gmailUserDisplayName() DEPRECATED_ATTRIBUTE;
@@ -220,6 +221,7 @@ namespace mailcore {
         dispatch_queue_t mDispatchQueue;
 #endif
         bool mIsGmail;
+        bool mIsMoveEnabled;
         bool mIsCondstoreEnabled;
         bool mIsQResyncEnabled;
         String * mGmailUserDisplayName;

--- a/src/core/imap/MCIMAPSession.cpp
+++ b/src/core/imap/MCIMAPSession.cpp
@@ -382,6 +382,7 @@ void IMAPSession::init()
     mNamespaceEnabled = false;
     mCompressionEnabled = false;
     mIsGmail = false;
+    mIsMoveEnabled = false;
     mAllowsNewPermanentFlags = false;
     mWelcomeString = NULL;
     mNeedsMboxMailWorkaround = false;
@@ -4235,6 +4236,9 @@ void IMAPSession::applyCapabilities(IndexSet * capabilities)
         mIdleEnabled = true;
         UNLOCK();
     }
+    if (capabilities->containsIndex(IMAPCapabilityMove)) {
+        mIsMoveEnabled = true;
+    }
     if (capabilities->containsIndex(IMAPCapabilityCondstore)) {
         mCondstoreEnabled = true;
     }
@@ -4310,6 +4314,11 @@ bool IMAPSession::allowsNewPermanentFlags() {
 bool IMAPSession::isGmail()
 {
     return mIsGmail;
+}
+
+bool IMAPSession::isMoveEnabled()
+{
+    return mIsMoveEnabled;
 }
 
 bool IMAPSession::isDisconnected()

--- a/src/core/imap/MCIMAPSession.h
+++ b/src/core/imap/MCIMAPSession.h
@@ -185,6 +185,7 @@ namespace mailcore {
         
         virtual bool isIdleEnabled();
         virtual bool isXListEnabled();
+        virtual bool isMoveEnabled();
         virtual bool isCondstoreEnabled();
         virtual bool isQResyncEnabled();
         virtual bool isIdentityEnabled();
@@ -262,6 +263,7 @@ namespace mailcore {
         bool mNamespaceEnabled;
         bool mCompressionEnabled;
         bool mIsGmail;
+        bool mIsMoveEnabled;
         bool mAllowsNewPermanentFlags;
         String * mWelcomeString;
         bool mNeedsMboxMailWorkaround;

--- a/src/objc/imap/MCOIMAPSession.h
+++ b/src/objc/imap/MCOIMAPSession.h
@@ -96,6 +96,9 @@
 /** If the server is Gmail */
 @property (nonatomic, assign, readonly) BOOL isGmail;
 
+/** If the server supports MOVE */
+@property (nonatomic, assign, readonly) BOOL isMoveEnabled;
+
 /** Does the server support CONDSTORE */
 @property (nonatomic, assign, readonly) BOOL isCondstoreEnabled;
 

--- a/src/objc/imap/MCOIMAPSession.mm
+++ b/src/objc/imap/MCOIMAPSession.mm
@@ -139,6 +139,11 @@ MCO_OBJC_SYNTHESIZE_SCALAR(dispatch_queue_t, dispatch_queue_t, setDispatchQueue,
     return MCO_NATIVE_INSTANCE->isGmail();
 }
 
+- (BOOL) isMoveEnabled
+{
+    return MCO_NATIVE_INSTANCE->isMoveEnabled();
+}
+
 - (BOOL) isCondstoreEnabled
 {
     return MCO_NATIVE_INSTANCE->isCondstoreEnabled();


### PR DESCRIPTION
MCIMAPSession was configuring an index property for the move capability, but it wasn't reporting it through its public API, and thus MCIMAPAsyncSession and MCOIMAPSession were not exposing it.