### PR TITLE
Mail/mail 861

### DIFF
--- a/scripts/include.sh/build-dep.sh
+++ b/scripts/include.sh/build-dep.sh
@@ -304,7 +304,20 @@ get_prebuilt_dep()
   
   installed_version="`defaults read "$installed_versions_path" "$name" 2>/dev/null`"
   if test ! -d "$scriptpath/../Externals/$name" ; then
-    installed_version=
+    echo "$name is not in Externals. Checking built products dir"
+
+    if test -f "${BUILT_PRODUCTS_DIR}/${name}.a" ; then
+      echo "Found product in built products dir, using that version. The version number of that"
+      echo "version is unknown, it is your responsability to ensure that it is up to date and is"
+      echo "configured properly with any required headers copied to $BUILT_PRODUCTS_DIR"
+
+      # Mark the version as up to date, even though the true version number is not known
+      installed_version="`defaults read "$versions_path" "$name" 2>/dev/null`"
+    else
+      # There is no version in BUILT_PRODUCTS_DIR so clear installed_version in order to 
+      # download a new copy
+      installed_version=
+    fi
   fi
   if test "x$installed_version" = x ; then
     installed_version="none"

--- a/src/async/imap/MCIMAPAsyncConnection.cpp
+++ b/src/async/imap/MCIMAPAsyncConnection.cpp
@@ -217,6 +217,16 @@ bool IMAPAsyncConnection::isCheckCertificateEnabled()
     return mSession->isCheckCertificateEnabled();
 }
 
+void IMAPAsyncConnection::setEnableMalformedAddressHack(bool enabled)
+{
+    mSession->setEnableMalformedAddressHack(enabled);
+}
+
+bool IMAPAsyncConnection::enableMalformedAddressHack()
+{
+    return mSession->enableMalformedAddressHack();
+}
+
 void IMAPAsyncConnection::setVoIPEnabled(bool enabled)
 {
     mSession->setVoIPEnabled(enabled);

--- a/src/async/imap/MCIMAPAsyncConnection.h
+++ b/src/async/imap/MCIMAPAsyncConnection.h
@@ -66,6 +66,9 @@ namespace mailcore {
         
         virtual void setCheckCertificateEnabled(bool enabled);
         virtual bool isCheckCertificateEnabled();
+
+        virtual void setEnableMalformedAddressHack(bool enabled);
+        virtual bool enableMalformedAddressHack();
         
         virtual void setVoIPEnabled(bool enabled);
         virtual bool isVoIPEnabled();

--- a/src/async/imap/MCIMAPAsyncSession.cpp
+++ b/src/async/imap/MCIMAPAsyncSession.cpp
@@ -194,16 +194,27 @@ bool IMAPAsyncSession::isCheckCertificateEnabled()
 
 void IMAPAsyncSession::setEnableMalformedAddressHack(bool enabled)
 {
+#ifdef LIBETPAN_HAS_MALFORMED_ADDRESS_HACK
     mEnableMalformedAddressHack = enabled;
     for(unsigned int i = 0 ; i < mSessions->count() ; i ++) {
         IMAPAsyncConnection * connection = (IMAPAsyncConnection *) mSessions->objectAtIndex(i);
         connection->setEnableMalformedAddressHack(enabled);
     }
+#endif
 }
 
 bool IMAPAsyncSession::enableMalformedAddressHack()
 {
     return mEnableMalformedAddressHack;
+}
+
+bool IMAPAsyncSession::supportsMalformedAddressHack()
+{
+#ifdef LIBETPAN_HAS_MALFORMED_ADDRESS_HACK
+    return true;
+#else
+    return false;
+#endif
 }
 
 void IMAPAsyncSession::setVoIPEnabled(bool enabled)

--- a/src/async/imap/MCIMAPAsyncSession.cpp
+++ b/src/async/imap/MCIMAPAsyncSession.cpp
@@ -46,6 +46,8 @@
 #include "MCIMAPMessageRenderingOperation.h"
 #include "MCIMAPCustomCommandOperation.h"
 
+#include <libetpan/libetpan.h>
+
 #define DEFAULT_MAX_CONNECTIONS 3
 
 using namespace mailcore;

--- a/src/async/imap/MCIMAPAsyncSession.cpp
+++ b/src/async/imap/MCIMAPAsyncSession.cpp
@@ -192,6 +192,20 @@ bool IMAPAsyncSession::isCheckCertificateEnabled()
     return mCheckCertificateEnabled;
 }
 
+void IMAPAsyncSession::setEnableMalformedAddressHack(bool enabled)
+{
+    mEnableMalformedAddressHack = enabled;
+    for(unsigned int i = 0 ; i < mSessions->count() ; i ++) {
+        IMAPAsyncConnection * connection = (IMAPAsyncConnection *) mSessions->objectAtIndex(i);
+        connection->setEnableMalformedAddressHack(enabled);
+    }
+}
+
+bool IMAPAsyncSession::enableMalformedAddressHack()
+{
+    return mEnableMalformedAddressHack;
+}
+
 void IMAPAsyncSession::setVoIPEnabled(bool enabled)
 {
     mVoIPEnabled = enabled;
@@ -352,6 +366,7 @@ IMAPAsyncConnection * IMAPAsyncSession::availableSession()
     if ((mMaximumConnections == 0) || (mSessions->count() < mMaximumConnections)) {
         chosenSession = session();
         mSessions->addObject(chosenSession);
+        chosenSession->setEnableMalformedAddressHack(mEnableMalformedAddressHack);
         return chosenSession;
     }
 

--- a/src/async/imap/MCIMAPAsyncSession.h
+++ b/src/async/imap/MCIMAPAsyncSession.h
@@ -78,6 +78,9 @@ namespace mailcore {
         
         virtual void setCheckCertificateEnabled(bool enabled);
         virtual bool isCheckCertificateEnabled();
+
+        virtual void setEnableMalformedAddressHack(bool enabled);
+        virtual bool enableMalformedAddressHack();
         
         virtual void setVoIPEnabled(bool enabled);
         virtual bool isVoIPEnabled();
@@ -207,6 +210,7 @@ namespace mailcore {
         ConnectionType mConnectionType;
         bool mCheckCertificateEnabled;
         bool mVoIPEnabled;
+        bool mEnableMalformedAddressHack;
         IMAPNamespace * mDefaultNamespace;
         time_t mTimeout;
         bool mAllowsFolderConcurrentAccessEnabled;

--- a/src/async/imap/MCIMAPAsyncSession.h
+++ b/src/async/imap/MCIMAPAsyncSession.h
@@ -81,6 +81,7 @@ namespace mailcore {
 
         virtual void setEnableMalformedAddressHack(bool enabled);
         virtual bool enableMalformedAddressHack();
+        virtual bool supportsMalformedAddressHack();
         
         virtual void setVoIPEnabled(bool enabled);
         virtual bool isVoIPEnabled();

--- a/src/core/imap/MCIMAPSession.cpp
+++ b/src/core/imap/MCIMAPSession.cpp
@@ -529,6 +529,19 @@ bool IMAPSession::isCheckCertificateEnabled()
     return mCheckCertificateEnabled;
 }
 
+void IMAPSession::setEnableMalformedAddressHack(bool enabled)
+{
+    malformedAddressWorkaroundEnabled = enabled;
+#ifdef LIBETPAN_HAS_MALFORMED_ADDRESS_HACK
+    mailimap_set_malformed_address_workaround_enabled(mImap, enabled);
+#endif
+}
+
+bool IMAPSession::enableMalformedAddressHack()
+{
+    return malformedAddressWorkaroundEnabled;
+}
+
 void IMAPSession::setVoIPEnabled(bool enabled)
 {
     mVoIPEnabled = enabled;
@@ -616,6 +629,9 @@ void IMAPSession::setup()
     mailimap_set_timeout(mImap, timeout());
     mailimap_set_progress_callback(mImap, body_progress, IMAPSession::items_progress, this);
     mailimap_set_logger(mImap, logger, this);
+#ifdef LIBETPAN_HAS_MALFORMED_ADDRESS_HACK
+    mailimap_set_malformed_address_workaround_enabled(mImap, malformedAddressWorkaroundEnabled);
+#endif
 }
 
 void IMAPSession::unsetup()

--- a/src/core/imap/MCIMAPSession.cpp
+++ b/src/core/imap/MCIMAPSession.cpp
@@ -531,8 +531,8 @@ bool IMAPSession::isCheckCertificateEnabled()
 
 void IMAPSession::setEnableMalformedAddressHack(bool enabled)
 {
-    malformedAddressWorkaroundEnabled = enabled;
 #ifdef LIBETPAN_HAS_MALFORMED_ADDRESS_HACK
+    malformedAddressWorkaroundEnabled = enabled;
     mailimap_set_malformed_address_workaround_enabled(mImap, enabled);
 #endif
 }

--- a/src/core/imap/MCIMAPSession.h
+++ b/src/core/imap/MCIMAPSession.h
@@ -55,6 +55,9 @@ namespace mailcore {
         
         virtual void setCheckCertificateEnabled(bool enabled);
         virtual bool isCheckCertificateEnabled();
+
+        virtual void setEnableMalformedAddressHack(bool enabled);
+        virtual bool enableMalformedAddressHack();
         
         virtual void setVoIPEnabled(bool enabled);
         virtual bool isVoIPEnabled();
@@ -276,6 +279,7 @@ namespace mailcore {
         bool mRamblerRuServer;
         bool mHermesServer;
         bool mQipServer;
+        bool malformedAddressWorkaroundEnabled;
         
         unsigned int mLastFetchedSequenceNumber;
         String * mCurrentFolder;

--- a/src/objc/imap/MCOIMAPSession.h
+++ b/src/objc/imap/MCOIMAPSession.h
@@ -108,6 +108,9 @@
 /** Enables or disables the malformed address hack for this session */
 @property (nonatomic, assign) BOOL enableMalformedAddressHack;
 
+/** Returns true if malformed address hack support was complied, false if not */
+@property (nonatomic, readonly) BOOL supportsMalformedAddressHack;
+
 /**
  Display name of the Gmail user. It will be nil if it's not a Gmail server.
 

--- a/src/objc/imap/MCOIMAPSession.h
+++ b/src/objc/imap/MCOIMAPSession.h
@@ -105,6 +105,9 @@
 /** Does the server support QRESYNC */
 @property (nonatomic, assign, readonly) BOOL isQResyncEnabled;
 
+/** Enables or disables the malformed address hack for this session */
+@property (nonatomic, assign) BOOL enableMalformedAddressHack;
+
 /**
  Display name of the Gmail user. It will be nil if it's not a Gmail server.
 

--- a/src/objc/imap/MCOIMAPSession.mm
+++ b/src/objc/imap/MCOIMAPSession.mm
@@ -129,6 +129,11 @@ MCO_OBJC_SYNTHESIZE_SCALAR(dispatch_queue_t, dispatch_queue_t, setDispatchQueue,
     return _session->enableMalformedAddressHack();
 }
 
+- (BOOL)supportsMalformedAddressHack
+{
+    return _session->supportsMalformedAddressHack();
+}
+
 - (MCOIMAPIdentity *) clientIdentity
 {
     return MCO_OBJC_BRIDGE_GET(clientIdentity);

--- a/src/objc/imap/MCOIMAPSession.mm
+++ b/src/objc/imap/MCOIMAPSession.mm
@@ -119,6 +119,16 @@ MCO_OBJC_SYNTHESIZE_SCALAR(dispatch_queue_t, dispatch_queue_t, setDispatchQueue,
     return MCO_TO_OBJC(_session->defaultNamespace());
 }
 
+- (void) setEnableMalformedAddressHack:(BOOL)enabled
+{
+    _session->setEnableMalformedAddressHack(enabled);
+}
+
+- (BOOL)enableMalformedAddressHack
+{
+    return _session->enableMalformedAddressHack();
+}
+
 - (MCOIMAPIdentity *) clientIdentity
 {
     return MCO_OBJC_BRIDGE_GET(clientIdentity);


### PR DESCRIPTION
This PR updates the mailcore build process to check built products for external dependancies before downloading and linking binaries. If a build product has been built locally before mailcore then it is not downloaded. If it has already been downloaded to externals then the downloaded version is used. This way it is possible to configure mailcore to build in the normal way, or using locally built dependancies. But it is essential that custom dependancies are built before mailcore or it will download the standard version and use that (and if your build folder contains the standard version already it will continue to use that).

The PR also adds API to expose the mailimap_set_malformed_address_workaround_enabled() API if libetpan has been compiled with that feature. If it has not it fails to enable it, so that the caller can verify which version it is accessing. This requires drilling through several layers of mailcore wrapper API.

NOTE: I'd like to switch from the modulemap branch to master for this repo (like our other subrepos) but I decided not to do that in this PR, since there's already enough going on here).